### PR TITLE
Remove enable service odl-compute/server

### DIFF
--- a/functions
+++ b/functions
@@ -185,8 +185,6 @@ enable_service q-l3
 enable_service q-meta
 enable_service quantum
 enable_service tempest
-enable_service odl-server
-enable_service odl-compute
 
 API_RATE_LIMIT=False
 


### PR DESCRIPTION
Because that is now done via networking-odl plugin
