### PR TITLE
Add getLatestLithiumUrl.sh to grab url for latest lithium build

### DIFF
--- a/tools/getLatestLithiumUrl.sh
+++ b/tools/getLatestLithiumUrl.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+URL_PREFIX=${ODLNEXUSPROXY:-https://nexus.opendaylight.org}
+NEXUSPATH="${URL_PREFIX}/content/repositories/opendaylight.snapshot/org/opendaylight/integration/distribution-karaf"
+BUNDLEVERSION='0.3.0-SNAPSHOT'
+
+# Acquire the timestamp information from maven-metadata.xml
+TFILE="/tmp/$(basename $0).$$.tmp"
+trap "rm -f '$TFILE'" exit
+wget --quiet -O ${TFILE}  ${NEXUSPATH}/${BUNDLEVERSION}/maven-metadata.xml
+
+BUNDLE_TIMESTAMP=$(xpath maven-metadata.xml "//snapshotVersion[extension='zip'][1]/value/text()" 2>/dev/null)
+ODL_NAME="distribution-karaf-${BUNDLEVERSION}"
+ODL_PKG="distribution-karaf-${BUNDLE_TIMESTAMP}.zip"
+ODL_URL="${NEXUSPATH}/${BUNDLEVERSION}"
+
+if [ "$1" == "-v" ]; then
+    echo "Nexus timestamp is ${BUNDLE_TIMESTAMP}"
+    echo "ODL_NAME=\"$ODL_NAME\""
+    echo "ODL_PKG=\"$ODL_PKG\""
+    echo "ODL_URL=\"$ODL_URL\""
+    echo ""
+fi
+
+echo "${NEXUSPATH}/${BUNDLEVERSION}/${ODL_PKG}"
+


### PR DESCRIPTION
getLatestLithiumUrl.sh

$ ./getLatestLithiumUrl.sh -v
Nexus timestamp is 0.3.0-20150421.171535-1196
ODL_NAME="distribution-karaf-0.3.0-SNAPSHOT"
ODL_PKG="distribution-karaf-0.3.0-20150421.171535-1196.zip"
ODL_URL="https://nexus.opendaylight.org/content/repositories/opendaylight.snapshot/org/opendaylight/integration/distribution-karaf/0.3.0-SNAPSHOT"

https://nexus.opendaylight.org/content/repositories/opendaylight.snapshot/org/opendaylight/integration/distribution-karaf/0.3.0-SNAPSHOT/distribution-karaf-0.3.0-20150421.171535-1196.zip
